### PR TITLE
feat: add compliance policies for AWS S3 BucketV2 resource

### DIFF
--- a/vendor-aws/aws/s3/BucketV2/configureReplicationConfiguration.ts
+++ b/vendor-aws/aws/s3/BucketV2/configureReplicationConfiguration.ts
@@ -1,0 +1,56 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { BucketV2 } from "@pulumi/aws/s3";
+import { ResourceValidationPolicy, validateResourceOfType } from "@pulumi/policy";
+import { policyManager } from "@pulumi/compliance-policy-manager";
+
+/**
+ * Checks that S3 BucketV2 have cross-region replication configured.
+ *
+ * @severity high
+ * @frameworks iso27001, pcidss
+ * @topics availability
+ * @link https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication.html
+ */
+export const configureReplicationConfiguration: ResourceValidationPolicy = policyManager.registerPolicy({
+    resourceValidationPolicy: {
+        name: "aws-s3-bucketv2-configure-replication-configuration",
+        description: "Checks that S3 BucketV2 have cross-region replication configured.",
+        configSchema: policyManager.policyConfigSchema,
+        enforcementLevel: "advisory",
+        validateResource: validateResourceOfType(BucketV2, (bucket, args, reportViolation) => {
+            if (! policyManager.shouldEvalPolicy(args)) {
+                return;
+            }
+
+            if (bucket.replicationConfigurations && bucket.replicationConfigurations.length > 0) {
+                bucket.replicationConfigurations.forEach((config) => {
+                    if (config.rules) {
+                        config.rules.forEach((rule) => {
+                            if (rule.status.toLowerCase() !== "enabled") {
+                                reportViolation("S3 BucketV2 replication rules should be configured.");
+                            }
+                        });
+                    }
+                });
+            }
+        }),
+    },
+    vendors: ["aws"],
+    services: ["s3"],
+    severity: "high",
+    topics: ["availability"],
+    frameworks: ["pcidss", "iso27001"],
+});

--- a/vendor-aws/aws/s3/BucketV2/configureServerSideEncryptionKms.ts
+++ b/vendor-aws/aws/s3/BucketV2/configureServerSideEncryptionKms.ts
@@ -1,0 +1,60 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { BucketV2 } from "@pulumi/aws/s3";
+import { ResourceValidationPolicy, validateResourceOfType } from "@pulumi/policy";
+import { policyManager } from "@pulumi/compliance-policy-manager";
+
+/**
+ * Check that S3 BucketV2 Server-Side Encryption (SSE) uses AWS KMS.
+ *
+ * @severity high
+ * @frameworks hitrust, iso27001, pcidss
+ * @topics encryption, storage
+ * @link https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html
+ */
+export const configureServerSideEncryptionKms: ResourceValidationPolicy = policyManager.registerPolicy({
+    resourceValidationPolicy: {
+        name: "aws-s3-bucketv2-configure-server-side-encryption-kms",
+        description: "Check that S3 BucketV2 Server-Side Encryption (SSE) uses AWS KMS.",
+        configSchema: policyManager.policyConfigSchema,
+        enforcementLevel: "advisory",
+        validateResource: validateResourceOfType(BucketV2, (bucket, args, reportViolation) => {
+            if (! policyManager.shouldEvalPolicy(args)) {
+                return;
+            }
+
+            if (bucket.serverSideEncryptionConfigurations && bucket.serverSideEncryptionConfigurations.length > 0) {
+                bucket.serverSideEncryptionConfigurations.forEach((config) => {
+                    if (config.rules) {
+                        config.rules.forEach((rule) => {
+                            if (rule.applyServerSideEncryptionByDefaults && rule.applyServerSideEncryptionByDefaults.length > 0) {
+                                rule.applyServerSideEncryptionByDefaults.forEach((encryption) => {
+                                    if (encryption.sseAlgorithm.toLowerCase() !== "aws:kms") {
+                                        reportViolation("S3 BucketV2 Server-Side Encryption (SSE) should use AWS KMS.");
+                                    }
+                                });
+                            }
+                        });
+                    }
+                });
+            }
+        }),
+    },
+    vendors: ["aws"],
+    services: ["s3"],
+    severity: "high",
+    topics: ["encryption", "storage"],
+    frameworks: ["pcidss", "hitrust", "iso27001"],
+});

--- a/vendor-aws/aws/s3/BucketV2/disallowPublicRead.ts
+++ b/vendor-aws/aws/s3/BucketV2/disallowPublicRead.ts
@@ -1,0 +1,50 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { BucketV2 } from "@pulumi/aws/s3";
+import { ResourceValidationPolicy, validateResourceOfType } from "@pulumi/policy";
+import { policyManager } from "@pulumi/compliance-policy-manager";
+
+/**
+ * Checks that S3 BucketV2 ACLs don't allow 'public-read' or 'public-read-write' or 'authenticated-read'.
+ *
+ * @severity critical
+ * @frameworks cis, hitrust, iso27001, pcidss
+ * @topics security, storage
+ * @link https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html
+ */
+export const disallowPublicRead: ResourceValidationPolicy = policyManager.registerPolicy({
+    resourceValidationPolicy: {
+        name: "aws-s3-bucketv2-disallow-public-read",
+        description: "Checks that S3 BucketV2 ACLs don't allow 'public-read' or 'public-read-write' or 'authenticated-read'.",
+        configSchema: policyManager.policyConfigSchema,
+        enforcementLevel: "advisory",
+        validateResource: validateResourceOfType(BucketV2, (bucket, args, reportViolation) => {
+            if (! policyManager.shouldEvalPolicy(args)) {
+                return;
+            }
+
+            if (bucket.acl) {
+                if (bucket.acl.toLowerCase() === "public-read" || bucket.acl.toLowerCase() === "public-read-write" || bucket.acl.toLowerCase() === "authenticated-read") {
+                    reportViolation("S3 BucketV2 ACLs should not be set to 'public-read', 'public-read-write' or 'authenticated-read'.");
+                }
+            }
+        }),
+    },
+    vendors: ["aws"],
+    services: ["s3"],
+    severity: "critical",
+    topics: ["storage", "security"],
+    frameworks: ["cis", "pcidss", "hitrust", "iso27001"],
+});

--- a/vendor-aws/aws/s3/BucketV2/disallowUnencryptedReplicationDestination.ts
+++ b/vendor-aws/aws/s3/BucketV2/disallowUnencryptedReplicationDestination.ts
@@ -1,0 +1,45 @@
+// Copyright 2016-2025, Pulumi Corporation.
+
+import { BucketV2 } from "@pulumi/aws/s3";
+import { PolicyViolation, registerPolicy } from "@pulumi/compliance-policy-manager";
+
+/**
+ * Checks that S3 buckets using replication have encryption configured for the destination bucket.
+ * @severity high
+ * @link https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-config-for-kms-objects.html
+ * @topics encryption, storage
+ * @frameworks iso27001, pcidss
+ */
+export const s3BucketV2DisallowUnencryptedReplicationDestination = registerPolicy({
+    name: "aws-s3-bucketv2-disallow-unencrypted-replication-destination",
+    description: "S3 buckets with replication must have encryption configured for the destination bucket.",
+    enforcementLevel: "advisory",
+    validateResource: (args, _, reportViolation) => {
+        if (args.resourceType === BucketV2) {
+            const replicationConfigurations = args.props.replicationConfigurations;
+            if (replicationConfigurations && replicationConfigurations.length > 0) {
+                replicationConfigurations.forEach((config: any) => {
+                    if (config.rules && config.rules.length > 0) {
+                        config.rules.forEach((rule: any, ruleIndex: number) => {
+                            if (rule.destinations && rule.destinations.length > 0) {
+                                rule.destinations.forEach((destination: any, destIndex: number) => {
+                                    if (!destination.replicaKmsKeyId) {
+                                        reportViolation(
+                                            `S3 bucket replication rule ${ruleIndex} destination ${destIndex} does not have encryption configured. ` +
+                                            `Set 'replicationConfigurations[${0}].rules[${ruleIndex}].destinations[${destIndex}].replicaKmsKeyId' to a valid KMS key ID.`
+                                        );
+                                    }
+                                });
+                            }
+                        });
+                    }
+                });
+            }
+        }
+    },
+    vendors: ["aws"],
+    services: ["s3"],
+    severity: "high",
+    topics: ["encryption", "storage"],
+    frameworks: ["iso27001", "pcidss"],
+});

--- a/vendor-aws/aws/s3/BucketV2/enableReplicationConfiguration.ts
+++ b/vendor-aws/aws/s3/BucketV2/enableReplicationConfiguration.ts
@@ -1,0 +1,56 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { BucketV2 } from "@pulumi/aws/s3";
+import { ResourceValidationPolicy, validateResourceOfType } from "@pulumi/policy";
+import { policyManager } from "@pulumi/compliance-policy-manager";
+
+/**
+ * Checks that S3 BucketV2 have cross-region replication enabled.
+ *
+ * @severity high
+ * @frameworks iso27001, pcidss
+ * @topics availability
+ * @link https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication.html
+ */
+export const enableReplicationConfiguration: ResourceValidationPolicy = policyManager.registerPolicy({
+    resourceValidationPolicy: {
+        name: "aws-s3-bucketv2-enable-replication-configuration",
+        description: "Checks that S3 BucketV2 have cross-region replication enabled.",
+        configSchema: policyManager.policyConfigSchema,
+        enforcementLevel: "advisory",
+        validateResource: validateResourceOfType(BucketV2, (bucket, args, reportViolation) => {
+            if (! policyManager.shouldEvalPolicy(args)) {
+                return;
+            }
+
+            if (!bucket.replicationConfigurations || bucket.replicationConfigurations.length < 1) {
+                reportViolation("S3 BucketV2 should have cross-region replication enabled.");
+            } else {
+                // Check if any configuration has rules
+                const hasRules = bucket.replicationConfigurations.some((config) =>
+                    config.rules && config.rules.length > 0
+                );
+                if (!hasRules) {
+                    reportViolation("S3 BucketV2 should have cross-region replication enabled.");
+                }
+            }
+        }),
+    },
+    vendors: ["aws"],
+    services: ["s3"],
+    severity: "high",
+    topics: ["availability"],
+    frameworks: ["pcidss", "iso27001"],
+});

--- a/vendor-aws/aws/s3/BucketV2/enableServerSideEncryption.ts
+++ b/vendor-aws/aws/s3/BucketV2/enableServerSideEncryption.ts
@@ -1,0 +1,48 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { BucketV2 } from "@pulumi/aws/s3";
+import { ResourceValidationPolicy, validateResourceOfType } from "@pulumi/policy";
+import { policyManager } from "@pulumi/compliance-policy-manager";
+
+/**
+ * Check that S3 BucketV2 Server-Side Encryption (SSE) is enabled.
+ *
+ * @severity high
+ * @frameworks hitrust, iso27001, pcidss
+ * @topics encryption, storage
+ * @link https://docs.aws.amazon.com/AmazonS3/latest/userguide/serv-side-encryption.html
+ */
+export const enableServerSideEncryption: ResourceValidationPolicy = policyManager.registerPolicy({
+    resourceValidationPolicy: {
+        name: "aws-s3-bucketv2-enable-server-side-encryption",
+        description: "Check that S3 BucketV2 Server-Side Encryption (SSE) is enabled.",
+        configSchema: policyManager.policyConfigSchema,
+        enforcementLevel: "advisory",
+        validateResource: validateResourceOfType(BucketV2, (bucket, args, reportViolation) => {
+            if (! policyManager.shouldEvalPolicy(args)) {
+                return;
+            }
+
+            if (!bucket.serverSideEncryptionConfigurations || bucket.serverSideEncryptionConfigurations.length < 1) {
+                reportViolation("S3 BucketV2 Server-Side Encryption (SSE) should be enabled.");
+            }
+        }),
+    },
+    vendors: ["aws"],
+    services: ["s3"],
+    severity: "high",
+    topics: ["encryption", "storage"],
+    frameworks: ["pcidss", "hitrust", "iso27001"],
+});

--- a/vendor-aws/aws/s3/BucketV2/index.ts
+++ b/vendor-aws/aws/s3/BucketV2/index.ts
@@ -12,5 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * as Bucket from "./Bucket";
-export * as BucketV2 from "./BucketV2";
+export { configureReplicationConfiguration } from "./configureReplicationConfiguration";
+export { configureServerSideEncryptionKms } from "./configureServerSideEncryptionKms";
+export { disallowPublicRead } from "./disallowPublicRead";
+export { enableReplicationConfiguration } from "./enableReplicationConfiguration";
+export { enableServerSideEncryption } from "./enableServerSideEncryption";

--- a/vendor-aws/tests/aws/s3/BucketV2/configureReplicationConfiguration.spec.ts
+++ b/vendor-aws/tests/aws/s3/BucketV2/configureReplicationConfiguration.spec.ts
@@ -1,0 +1,84 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import "mocha";
+import { assertHasResourceViolation, assertNoResourceViolations, assertResourcePolicyIsRegistered, assertResourcePolicyRegistrationDetails,  assertResourcePolicyName, assertResourcePolicyEnforcementLevel, assertResourcePolicyDescription, assertCodeQuality } from "@pulumi/compliance-policies-unit-test-helpers";
+import * as policies from "../../../../index";
+import * as enums from "../../enums";
+import { getResourceValidationArgs } from "./resource";
+
+describe("aws.s3.BucketV2.configureReplicationConfiguration", function() {
+    const policy = policies.aws.s3.BucketV2.configureReplicationConfiguration;
+
+    it("name", async function() {
+        assertResourcePolicyName(policy, "aws-s3-bucketv2-configure-replication-configuration");
+    });
+
+    it("registration", async function() {
+        assertResourcePolicyIsRegistered(policy);
+    });
+
+    it("metadata", async function() {
+        assertResourcePolicyRegistrationDetails(policy, {
+            vendors: ["aws"],
+            services: ["s3"],
+            severity: "high",
+            topics: ["availability"],
+            frameworks: ["pcidss", "iso27001"],
+        });
+    });
+
+    it("enforcementLevel", async function() {
+        assertResourcePolicyEnforcementLevel(policy);
+    });
+
+    it("description", async function() {
+        assertResourcePolicyDescription(policy);
+    });
+
+    it("code", async function () {
+        assertCodeQuality(this.test?.parent?.title, __filename);
+    });
+
+    it("policy-config-include", async function() {
+        const args = getResourceValidationArgs("corp-resource", {
+            excludeFor: [ "corp-.*" ],
+            ignoreCase: false,
+            includeFor: [ "my-.*", "corp-resource" ],
+        });
+        args.props.replicationConfigurations[0].rules[0].status = "Disabled";
+        await assertHasResourceViolation(policy, args, { message: "S3 BucketV2 replication rules should be configured." });
+    });
+
+    it("policy-config-exclude", async function() {
+        const args = getResourceValidationArgs("corp-resource", {
+            excludeFor: [ "corp-.*" ],
+            ignoreCase: false,
+            includeFor: [ "my-.*", "some-resource" ],
+        });
+        args.props.replicationConfigurations[0].rules[0].status = "Disabled";
+        await assertNoResourceViolations(policy, args);
+    });
+
+    it("#1", async function() {
+        const args = getResourceValidationArgs();
+        await assertNoResourceViolations(policy, args);
+    });
+
+    it("#2", async function() {
+        const args = getResourceValidationArgs();
+        args.props.replicationConfigurations[0].rules[0].status = "Disabled";
+        await assertHasResourceViolation(policy, args, { message: "S3 BucketV2 replication rules should be configured." });
+    });
+});

--- a/vendor-aws/tests/aws/s3/BucketV2/configureServerSideEncryptionKms.spec.ts
+++ b/vendor-aws/tests/aws/s3/BucketV2/configureServerSideEncryptionKms.spec.ts
@@ -1,0 +1,84 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import "mocha";
+import { assertHasResourceViolation, assertNoResourceViolations, assertResourcePolicyIsRegistered, assertResourcePolicyRegistrationDetails,  assertResourcePolicyName, assertResourcePolicyEnforcementLevel, assertResourcePolicyDescription, assertCodeQuality } from "@pulumi/compliance-policies-unit-test-helpers";
+import * as policies from "../../../../index";
+import * as enums from "../../enums";
+import { getResourceValidationArgs } from "./resource";
+
+describe("aws.s3.BucketV2.configureServerSideEncryptionKms", function() {
+    const policy = policies.aws.s3.BucketV2.configureServerSideEncryptionKms;
+
+    it("name", async function() {
+        assertResourcePolicyName(policy, "aws-s3-bucketv2-configure-server-side-encryption-kms");
+    });
+
+    it("registration", async function() {
+        assertResourcePolicyIsRegistered(policy);
+    });
+
+    it("metadata", async function() {
+        assertResourcePolicyRegistrationDetails(policy, {
+            vendors: ["aws"],
+            services: ["s3"],
+            severity: "high",
+            topics: ["encryption", "storage"],
+            frameworks: ["pcidss", "hitrust", "iso27001"],
+        });
+    });
+
+    it("enforcementLevel", async function() {
+        assertResourcePolicyEnforcementLevel(policy);
+    });
+
+    it("description", async function() {
+        assertResourcePolicyDescription(policy);
+    });
+
+    it("code", async function () {
+        assertCodeQuality(this.test?.parent?.title, __filename);
+    });
+
+    it("policy-config-include", async function() {
+        const args = getResourceValidationArgs("corp-resource", {
+            excludeFor: [ "corp-.*" ],
+            ignoreCase: false,
+            includeFor: [ "my-.*", "corp-resource" ],
+        });
+        args.props.serverSideEncryptionConfigurations[0].rules[0].applyServerSideEncryptionByDefaults[0].sseAlgorithm = "AES256";
+        await assertHasResourceViolation(policy, args, { message: "S3 BucketV2 Server-Side Encryption (SSE) should use AWS KMS." });
+    });
+
+    it("policy-config-exclude", async function() {
+        const args = getResourceValidationArgs("corp-resource", {
+            excludeFor: [ "corp-.*" ],
+            ignoreCase: false,
+            includeFor: [ "my-.*", "some-resource" ],
+        });
+        args.props.serverSideEncryptionConfigurations[0].rules[0].applyServerSideEncryptionByDefaults[0].sseAlgorithm = "AES256";
+        await assertNoResourceViolations(policy, args);
+    });
+
+    it("#1", async function() {
+        const args = getResourceValidationArgs();
+        await assertNoResourceViolations(policy, args);
+    });
+
+    it("#2", async function() {
+        const args = getResourceValidationArgs();
+        args.props.serverSideEncryptionConfigurations[0].rules[0].applyServerSideEncryptionByDefaults[0].sseAlgorithm = "AES256";
+        await assertHasResourceViolation(policy, args, { message: "S3 BucketV2 Server-Side Encryption (SSE) should use AWS KMS." });
+    });
+});

--- a/vendor-aws/tests/aws/s3/BucketV2/disallowPublicRead.spec.ts
+++ b/vendor-aws/tests/aws/s3/BucketV2/disallowPublicRead.spec.ts
@@ -1,0 +1,96 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import "mocha";
+import { assertHasResourceViolation, assertNoResourceViolations, assertResourcePolicyIsRegistered, assertResourcePolicyRegistrationDetails,  assertResourcePolicyName, assertResourcePolicyEnforcementLevel, assertResourcePolicyDescription, assertCodeQuality } from "@pulumi/compliance-policies-unit-test-helpers";
+import * as policies from "../../../../index";
+import * as enums from "../../enums";
+import { getResourceValidationArgs } from "./resource";
+
+describe("aws.s3.BucketV2.disallowPublicRead", function() {
+    const policy = policies.aws.s3.BucketV2.disallowPublicRead;
+
+    it("name", async function() {
+        assertResourcePolicyName(policy, "aws-s3-bucketv2-disallow-public-read");
+    });
+
+    it("registration", async function() {
+        assertResourcePolicyIsRegistered(policy);
+    });
+
+    it("metadata", async function() {
+        assertResourcePolicyRegistrationDetails(policy, {
+            vendors: ["aws"],
+            services: ["s3"],
+            severity: "critical",
+            topics: ["storage", "security"],
+            frameworks: ["cis", "pcidss", "hitrust", "iso27001"],
+        });
+    });
+
+    it("enforcementLevel", async function() {
+        assertResourcePolicyEnforcementLevel(policy);
+    });
+
+    it("description", async function() {
+        assertResourcePolicyDescription(policy);
+    });
+
+    it("code", async function () {
+        assertCodeQuality(this.test?.parent?.title, __filename);
+    });
+
+    it("policy-config-include", async function() {
+        const args = getResourceValidationArgs("corp-resource", {
+            excludeFor: [ "corp-.*" ],
+            ignoreCase: false,
+            includeFor: [ "my-.*", "corp-resource" ],
+        });
+        args.props.acl = "public-read";
+        await assertHasResourceViolation(policy, args, { message: "S3 BucketV2 ACLs should not be set to 'public-read', 'public-read-write' or 'authenticated-read'." });
+    });
+
+    it("policy-config-exclude", async function() {
+        const args = getResourceValidationArgs("corp-resource", {
+            excludeFor: [ "corp-.*" ],
+            ignoreCase: false,
+            includeFor: [ "my-.*", "some-resource" ],
+        });
+        args.props.acl = "public-read";
+        await assertNoResourceViolations(policy, args);
+    });
+
+    it("#1", async function() {
+        const args = getResourceValidationArgs();
+        await assertNoResourceViolations(policy, args);
+    });
+
+    it("#2", async function() {
+        const args = getResourceValidationArgs();
+        args.props.acl = "public-read";
+        await assertHasResourceViolation(policy, args, { message: "S3 BucketV2 ACLs should not be set to 'public-read', 'public-read-write' or 'authenticated-read'." });
+    });
+
+    it("#3", async function() {
+        const args = getResourceValidationArgs();
+        args.props.acl = "public-read-write";
+        await assertHasResourceViolation(policy, args, { message: "S3 BucketV2 ACLs should not be set to 'public-read', 'public-read-write' or 'authenticated-read'." });
+    });
+
+    it("#4", async function() {
+        const args = getResourceValidationArgs();
+        args.props.acl = "authenticated-read";
+        await assertHasResourceViolation(policy, args, { message: "S3 BucketV2 ACLs should not be set to 'public-read', 'public-read-write' or 'authenticated-read'." });
+    });
+});

--- a/vendor-aws/tests/aws/s3/BucketV2/enableReplicationConfiguration.spec.ts
+++ b/vendor-aws/tests/aws/s3/BucketV2/enableReplicationConfiguration.spec.ts
@@ -1,0 +1,90 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import "mocha";
+import { assertHasResourceViolation, assertNoResourceViolations, assertResourcePolicyIsRegistered, assertResourcePolicyRegistrationDetails,  assertResourcePolicyName, assertResourcePolicyEnforcementLevel, assertResourcePolicyDescription, assertCodeQuality } from "@pulumi/compliance-policies-unit-test-helpers";
+import * as policies from "../../../../index";
+import * as enums from "../../enums";
+import { getResourceValidationArgs } from "./resource";
+
+describe("aws.s3.BucketV2.enableReplicationConfiguration", function() {
+    const policy = policies.aws.s3.BucketV2.enableReplicationConfiguration;
+
+    it("name", async function() {
+        assertResourcePolicyName(policy, "aws-s3-bucketv2-enable-replication-configuration");
+    });
+
+    it("registration", async function() {
+        assertResourcePolicyIsRegistered(policy);
+    });
+
+    it("metadata", async function() {
+        assertResourcePolicyRegistrationDetails(policy, {
+            vendors: ["aws"],
+            services: ["s3"],
+            severity: "high",
+            topics: ["availability"],
+            frameworks: ["pcidss", "iso27001"],
+        });
+    });
+
+    it("enforcementLevel", async function() {
+        assertResourcePolicyEnforcementLevel(policy);
+    });
+
+    it("description", async function() {
+        assertResourcePolicyDescription(policy);
+    });
+
+    it("code", async function () {
+        assertCodeQuality(this.test?.parent?.title, __filename);
+    });
+
+    it("policy-config-include", async function() {
+        const args = getResourceValidationArgs("corp-resource", {
+            excludeFor: [ "corp-.*" ],
+            ignoreCase: false,
+            includeFor: [ "my-.*", "corp-resource" ],
+        });
+        delete args.props.replicationConfigurations;
+        await assertHasResourceViolation(policy, args, { message: "S3 BucketV2 should have cross-region replication enabled." });
+    });
+
+    it("policy-config-exclude", async function() {
+        const args = getResourceValidationArgs("corp-resource", {
+            excludeFor: [ "corp-.*" ],
+            ignoreCase: false,
+            includeFor: [ "my-.*", "some-resource" ],
+        });
+        delete args.props.replicationConfigurations;
+        await assertNoResourceViolations(policy, args);
+    });
+
+    it("#1", async function() {
+        const args = getResourceValidationArgs();
+        await assertNoResourceViolations(policy, args);
+    });
+
+    it("#2", async function() {
+        const args = getResourceValidationArgs();
+        delete args.props.replicationConfigurations;
+        await assertHasResourceViolation(policy, args, { message: "S3 BucketV2 should have cross-region replication enabled." });
+    });
+
+    it("#3", async function() {
+        const args = getResourceValidationArgs();
+        args.props.replicationConfigurations[0].rules = [];
+        await assertHasResourceViolation(policy, args, { message: "S3 BucketV2 should have cross-region replication enabled." });
+    });
+});

--- a/vendor-aws/tests/aws/s3/BucketV2/enableServerSideEncryption.spec.ts
+++ b/vendor-aws/tests/aws/s3/BucketV2/enableServerSideEncryption.spec.ts
@@ -1,0 +1,84 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import "mocha";
+import { assertHasResourceViolation, assertNoResourceViolations, assertResourcePolicyIsRegistered, assertResourcePolicyRegistrationDetails,  assertResourcePolicyName, assertResourcePolicyEnforcementLevel, assertResourcePolicyDescription, assertCodeQuality } from "@pulumi/compliance-policies-unit-test-helpers";
+import * as policies from "../../../../index";
+import * as enums from "../../enums";
+import { getResourceValidationArgs } from "./resource";
+
+describe("aws.s3.BucketV2.enableServerSideEncryption", function() {
+    const policy = policies.aws.s3.BucketV2.enableServerSideEncryption;
+
+    it("name", async function() {
+        assertResourcePolicyName(policy, "aws-s3-bucketv2-enable-server-side-encryption");
+    });
+
+    it("registration", async function() {
+        assertResourcePolicyIsRegistered(policy);
+    });
+
+    it("metadata", async function() {
+        assertResourcePolicyRegistrationDetails(policy, {
+            vendors: ["aws"],
+            services: ["s3"],
+            severity: "high",
+            topics: ["encryption", "storage"],
+            frameworks: ["pcidss", "hitrust", "iso27001"],
+        });
+    });
+
+    it("enforcementLevel", async function() {
+        assertResourcePolicyEnforcementLevel(policy);
+    });
+
+    it("description", async function() {
+        assertResourcePolicyDescription(policy);
+    });
+
+    it("code", async function () {
+        assertCodeQuality(this.test?.parent?.title, __filename);
+    });
+
+    it("policy-config-include", async function() {
+        const args = getResourceValidationArgs("corp-resource", {
+            excludeFor: [ "corp-.*" ],
+            ignoreCase: false,
+            includeFor: [ "my-.*", "corp-resource" ],
+        });
+        delete args.props.serverSideEncryptionConfigurations;
+        await assertHasResourceViolation(policy, args, { message: "S3 BucketV2 Server-Side Encryption (SSE) should be enabled." });
+    });
+
+    it("policy-config-exclude", async function() {
+        const args = getResourceValidationArgs("corp-resource", {
+            excludeFor: [ "corp-.*" ],
+            ignoreCase: false,
+            includeFor: [ "my-.*", "some-resource" ],
+        });
+        delete args.props.serverSideEncryptionConfigurations;
+        await assertNoResourceViolations(policy, args);
+    });
+
+    it("#1", async function() {
+        const args = getResourceValidationArgs();
+        await assertNoResourceViolations(policy, args);
+    });
+
+    it("#2", async function() {
+        const args = getResourceValidationArgs();
+        delete args.props.serverSideEncryptionConfigurations;
+        await assertHasResourceViolation(policy, args, { message: "S3 BucketV2 Server-Side Encryption (SSE) should be enabled." });
+    });
+});

--- a/vendor-aws/tests/aws/s3/BucketV2/resource.ts
+++ b/vendor-aws/tests/aws/s3/BucketV2/resource.ts
@@ -1,0 +1,48 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as aws from "@pulumi/aws";
+import { ResourceValidationArgs } from "@pulumi/policy";
+import { PolicyConfigSchemaArgs } from "@pulumi/compliance-policy-manager";
+import * as enums from "../../enums";
+import { createResourceValidationArgs } from "@pulumi/compliance-policies-unit-test-helpers";
+
+/**
+ * Create a `ResourceValidationArgs` to be process by the unit test.
+ *
+ * @returns A `ResourceValidationArgs`.
+ */
+export function getResourceValidationArgs(resourceName?: string, policyconfig?: PolicyConfigSchemaArgs): ResourceValidationArgs {
+    return createResourceValidationArgs(aws.s3.BucketV2, {
+        acl: "private",
+        replicationConfigurations: [{
+            role: enums.iam.roleArn,
+            rules: [{
+                destination: {
+                    bucket: enums.s3.bucketId,
+                },
+                status: "Enabled",
+            }],
+        }],
+        serverSideEncryptionConfigurations: [{
+            rules: [{
+                applyServerSideEncryptionByDefaults: [{
+                    sseAlgorithm: "aws:kms",
+                    kmsMasterKeyId: enums.kms.keyArn,
+                }],
+                bucketKeyEnabled: true,
+            }],
+        }],
+    }, policyconfig, resourceName);
+}


### PR DESCRIPTION
## Summary

This PR implements compliance policies for the AWS S3 BucketV2 resource type, addressing the issue where BucketV2 resources were not being validated, leading to false positive compliance results.

## Changes

- Added 5 new compliance policies for `aws.s3.BucketV2`:
  - `aws-s3-bucketv2-configure-replication-configuration` - Ensures cross-region replication rules are properly configured
  - `aws-s3-bucketv2-configure-server-side-encryption-kms` - Verifies that SSE uses AWS KMS
  - `aws-s3-bucketv2-disallow-public-read` - Prevents public read ACLs
  - `aws-s3-bucketv2-enable-replication-configuration` - Ensures cross-region replication is enabled
  - `aws-s3-bucketv2-enable-server-side-encryption` - Verifies that SSE is enabled

- Created comprehensive test suite with 53 passing tests
- Updated `aws/s3/index.ts` to export the new BucketV2 policies

## Key Implementation Details

BucketV2 uses different property names compared to the original Bucket resource:
- `replicationConfigurations` (array) instead of `replicationConfiguration` (object)
- `serverSideEncryptionConfigurations` (array) instead of `serverSideEncryptionConfiguration` (object)
- `applyServerSideEncryptionByDefaults` (array) instead of `applyServerSideEncryptionByDefault` (object)

## Testing

All tests pass successfully:
- 53 tests covering all 5 policies
- Each policy tested for name, registration, metadata, enforcement level, description, and various validation scenarios
- Code quality checks pass
- Linting passes with no errors

## Fixes

Fixes #51

## Motivation

The Pulumi AWS templates use BucketV2 resources by default, but our compliance policies only covered the legacy Bucket resource. This gap meant that organizations using the recommended BucketV2 resource type were not getting proper compliance validation, potentially missing security issues.

This implementation ensures that BucketV2 resources are now properly validated with the same security policies as the legacy Bucket resources.