### PR TITLE
feat: ec2 launch template enforce IMDSv2

### DIFF
--- a/vendor-aws/aws/ec2/LaunchTemplate/enforceImdsv2.ts
+++ b/vendor-aws/aws/ec2/LaunchTemplate/enforceImdsv2.ts
@@ -1,0 +1,68 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { LaunchTemplate } from "@pulumi/aws/ec2";
+import { ResourceValidationPolicy, validateResourceOfType } from "@pulumi/policy";
+import { policyManager } from "@pulumi/compliance-policy-manager";
+
+/**
+ * Enforces EC2 Launch Templates to use IMDSv2 by requiring httpTokens='required'
+ * whenever the Instance Metadata Service endpoint is enabled.
+ * Disabling the IMDS endpoint is also allowed.
+ *
+ * @severity high
+ * @frameworks cis, iso27001, pcidss, hitrust
+ * @topics hardening, network
+ * @link https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
+ */
+export const enforceImdsv2: ResourceValidationPolicy = policyManager.registerPolicy({
+    resourceValidationPolicy: {
+        name: "aws-ec2-launchtemplate-enforce-imdsv2",
+        description: "Ensures EC2 Launch Templates require IMDSv2 (httpTokens='required') or disable the IMDS endpoint.",
+        configSchema: policyManager.policyConfigSchema,
+        enforcementLevel: "mandatory",
+        validateResource: validateResourceOfType(LaunchTemplate, (lt, args, reportViolation) => {
+            if (!policyManager.shouldEvalPolicy(args)) {
+                return;
+            }
+
+            const md = lt.metadataOptions;
+
+            // If metadataOptions not provided, defaults allow IMDSv1. Violation.
+            if (!md) {
+                reportViolation(
+                    "EC2 Launch Templates must configure metadataOptions.httpTokens='required' to enforce IMDSv2, or disable the metadata endpoint."
+                );
+                return;
+            }
+
+            // If IMDS endpoint is disabled, it's compliant.
+            if (md.httpEndpoint === "disabled") {
+                return;
+            }
+
+            // With endpoint enabled (default or explicitly enabled), tokens must be required.
+            if (md.httpTokens !== "required") {
+                reportViolation(
+                    "EC2 Launch Templates must set metadataOptions.httpTokens='required' to enforce IMDSv2."
+                );
+            }
+        }),
+    },
+    vendors: ["aws"],
+    services: ["ec2"],
+    severity: "high",
+    topics: ["hardening", "network"],
+    frameworks: ["cis", "pcidss", "hitrust", "iso27001"],
+});

--- a/vendor-aws/aws/ec2/LaunchTemplate/index.ts
+++ b/vendor-aws/aws/ec2/LaunchTemplate/index.ts
@@ -15,3 +15,4 @@
 export { disallowPublicIp } from "./disallowPublicIp";
 export { disallowUnencryptedBlockDevice } from "./disallowUnencryptedBlockDevice";
 export { configureCustomerManagedKey } from "./configureCustomerManagedKey";
+export { enforceImdsv2 } from "./enforceImdsv2";

--- a/vendor-aws/tests/aws/ec2/LaunchTemplate/enforceImdsv2.spec.ts
+++ b/vendor-aws/tests/aws/ec2/LaunchTemplate/enforceImdsv2.spec.ts
@@ -1,0 +1,109 @@
+import "mocha";
+import {
+    assertHasResourceViolation,
+    assertNoResourceViolations,
+    assertResourcePolicyIsRegistered,
+    assertResourcePolicyRegistrationDetails,
+    assertResourcePolicyName,
+    assertResourcePolicyEnforcementLevel,
+    assertResourcePolicyDescription,
+    assertCodeQuality,
+} from "@pulumi/compliance-policies-unit-test-helpers";
+import * as policies from "../../../../index";
+import * as enums from "../../enums";
+import { getResourceValidationArgs } from "./resource";
+
+describe("aws.ec2.LaunchTemplate.enforceImdsv2", function () {
+    const policy = policies.aws.ec2.LaunchTemplate.enforceImdsv2;
+
+    it("name", async function () {
+        assertResourcePolicyName(policy, "aws-ec2-launchtemplate-enforce-imdsv2");
+    });
+
+    it("registration", async function () {
+        assertResourcePolicyIsRegistered(policy);
+    });
+
+    it("metadata", async function () {
+        assertResourcePolicyRegistrationDetails(policy, {
+            vendors: ["aws"],
+            services: ["ec2"],
+            severity: "high",
+            topics: ["hardening", "network"],
+            frameworks: ["cis", "pcidss", "hitrust", "iso27001"],
+        });
+    });
+
+    it("enforcementLevel", async function () {
+        assertResourcePolicyEnforcementLevel(policy);
+    });
+
+    it("description", async function () {
+        assertResourcePolicyDescription(policy);
+    });
+
+    it("code", async function () {
+        assertCodeQuality(this.test?.parent?.title, __filename);
+    });
+
+    it("policy-config-include", async function () {
+        const args = getResourceValidationArgs("corp-resource", {
+            excludeFor: ["corp-.*"],
+            ignoreCase: false,
+            includeFor: ["my-.*", "corp-resource"],
+        });
+        // Compliant when included
+        args.props.metadataOptions = {
+            httpTokens: "required",
+        };
+        await assertNoResourceViolations(policy, args);
+    });
+
+    it("policy-config-exclude", async function () {
+        const args = getResourceValidationArgs("corp-resource", {
+            excludeFor: ["corp-.*"],
+            ignoreCase: false,
+            includeFor: ["my-.*", "some-resource"],
+        });
+        // Non-compliant but excluded => no violations
+        args.props.metadataOptions = {
+            httpTokens: "optional",
+        };
+        await assertNoResourceViolations(policy, args);
+    });
+
+    it("#1 compliant: tokens required", async function () {
+        const args = getResourceValidationArgs();
+        args.props.metadataOptions = {
+            httpTokens: "required",
+        };
+        await assertNoResourceViolations(policy, args);
+    });
+
+    it("#2 violation: tokens not required", async function () {
+        const args = getResourceValidationArgs();
+        args.props.metadataOptions = {
+            httpTokens: "optional",
+        };
+        await assertHasResourceViolation(policy, args, {
+            message: "EC2 Launch Templates must set metadataOptions.httpTokens='required' to enforce IMDSv2.",
+        });
+    });
+
+    it("#3 compliant: endpoint disabled", async function () {
+        const args = getResourceValidationArgs();
+        args.props.metadataOptions = {
+            httpEndpoint: "disabled",
+        };
+        await assertNoResourceViolations(policy, args);
+    });
+
+    it("#4 violation: metadataOptions missing", async function () {
+        const args = getResourceValidationArgs();
+        args.props.metadataOptions = undefined;
+        await assertHasResourceViolation(policy, args, {
+            message:
+                "EC2 Launch Templates must configure metadataOptions.httpTokens='required' to enforce IMDSv2, or disable the metadata endpoint.",
+        });
+    });
+});


### PR DESCRIPTION
Adds a mandatory Pulumi compliance policy that enforces Instance Metadata Service v2 (IMDSv2) on EC2 Launch Templates by requiring metadataOptions.httpTokens = "required" when the IMDS endpoint is enabled. Disabling the IMDS endpoint is also permitted.